### PR TITLE
Allow drawing with non-volatile images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dependency:
 <dependency>
     <groupId>com.github.Valkryst</groupId>
     <artifactId>V2DSprite</artifactId>
-    <version>2020.01.20-FULL_REWRITE.0</version>
+    <version>2020.04.05</version>
 </dependency>
 ```
 

--- a/V2DSprite.iml
+++ b/V2DSprite.iml
@@ -9,16 +9,11 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-test-sources/test-annotations" isTestSource="true" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="jdk" jdkName="11.0.2" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.10" level="project" />
-    <orderEntry type="library" name="Maven: org.json:json:20190722" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.10" level="project" />
-    <orderEntry type="library" name="Maven: org.json:json:20190722" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.10" level="project" />
     <orderEntry type="library" name="Maven: org.json:json:20190722" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.13" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Valkryst</groupId>
     <artifactId>V2DSprite</artifactId>
-    <version>2020.01.20-FULL_REWRITE.0</version>
+    <version>2020.04.05</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/com/valkryst/V2DSprite/Sprite.java
+++ b/src/main/java/com/valkryst/V2DSprite/Sprite.java
@@ -6,10 +6,11 @@ import java.util.MissingFormatArgumentException;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import org.json.JSONObject;
 
 public class Sprite {
-    /** The com.valkryst.V2DSprite.SpriteSheet containing this sprite. */
+    /** The SpriteSheet containing this sprite. */
     private final SpriteSheet spriteSheet;
 
     /** The x-axis position of the top-left pixel, within the sprite sheet. */
@@ -21,6 +22,13 @@ public class Sprite {
     @Getter private final short width;
     /** The height. */
     @Getter private final short height;
+
+    /**
+     * Whether the sprite should be drawn using a
+     * {@link java.awt.image.VolatileImage} or a
+     * {@link java.awt.image.BufferedImage}.
+     */
+    @Setter public boolean useVolatileImage = true;
 
     /**
      * Constructs a new sprite.
@@ -96,7 +104,8 @@ public class Sprite {
      *          The position, on the graphics context, to draw this sprite.
      */
     public void draw(final @NonNull Graphics2D gc, final @NonNull Point position) {
-        gc.drawImage(spriteSheet.getImage(), position.x, position.y, position.x + width, position.y + height, x, y, x + width, y + height, null);
+        final var image = useVolatileImage ? spriteSheet.getImage() : spriteSheet.getBufferedImage();
+        gc.drawImage(image, position.x, position.y, position.x + width, position.y + height, x, y, x + width, y + height, null);
     }
 
     /**

--- a/src/main/java/com/valkryst/V2DSprite/SpriteSheet.java
+++ b/src/main/java/com/valkryst/V2DSprite/SpriteSheet.java
@@ -1,5 +1,6 @@
 package com.valkryst.V2DSprite;
 
+import lombok.Getter;
 import lombok.NonNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -19,7 +20,7 @@ import java.util.Optional;
 
 public class SpriteSheet {
     /** The original image, loaded from disk. */
-    private final BufferedImage bufferedImage;
+    @Getter private final BufferedImage bufferedImage;
     /** The volatile image, created from the original image. */
     private VolatileImage volatileImage;
 


### PR DESCRIPTION
* Add the `useVolatileImage` instance variable to the `Sprite` class
* Add a `@Getter` annotation to the `bufferedImage` instance variable of the `SpriteSheet` class
* Fix JavaDoc error in the `SpriteSheet` class
* Update version from `2020.01.20-FULL_REWRITE.0` to `2020.04.05`