### PR TITLE
Fix issue where `Sprite.useVolatileImage` was set to `public`, rather than `private`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dependency:
 <dependency>
     <groupId>com.github.Valkryst</groupId>
     <artifactId>V2DSprite</artifactId>
-    <version>2020.04.05</version>
+    <version>2020.04.05-break</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.Valkryst</groupId>
     <artifactId>V2DSprite</artifactId>
-    <version>2020.04.05</version>
+    <version>2020.04.05-break</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/com/valkryst/V2DSprite/Sprite.java
+++ b/src/main/java/com/valkryst/V2DSprite/Sprite.java
@@ -28,7 +28,7 @@ public class Sprite {
      * {@link java.awt.image.VolatileImage} or a
      * {@link java.awt.image.BufferedImage}.
      */
-    @Setter public boolean useVolatileImage = true;
+    @Setter private boolean useVolatileImage = true;
 
     /**
      * Constructs a new sprite.


### PR DESCRIPTION
* Fix issue where `Sprite.useVolatileImage` was set to `public`, rather than `private`
* Update version from `2020.04.05` to `2020.04.05-break`